### PR TITLE
wrong "Add-Migration" command and steps to fix an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 <img src="https://www.mysql.com/common/logos/logo-mysql-170x115.png" height="100" width="150"/>
 
 MySQL is a Database Management System from Oracle that currently supports Entity Framework through the MySQL ADO.NET Connector a fully-managed ADO.NET driver for MySQL.. I will go through steps in setting up MySQL with Entity framework 6.1.+ Using Visual Studio.
+#### Note: 
+This Tutorial also works with MariaDB.
 
 **PREREQUISITES**
 - Visual Studio<br/>
@@ -106,3 +108,20 @@ PM> Update-Database -Verbose
 ```
 
 You should see your Product Table Created in Your MySql Server
+
+#### Note:
+If you get a **System.TypeLoadException** when adding a migration, you should try to install a older version of the MySQL packages.
+</br>
+To do so, follow these steps:
+1. Open the Package Manager Console: **Tools > NuGet Package Manager > Package Manager Console**
+2. Uninstall the current Packages:
+``` 
+PM> Uninstall-Package MySQL.Data
+PM> Uninstall-Package MySQL.Data.Entity 
+```
+` PM> Uninstall-Package MySQL.Data `
+3. Install the older packages:
+```
+PM> Install-Package MySQL.Data -Version [type in the tabulator and you'll see the available versions] `
+PM> Install-Package MySQL.Data.Entity -Version [select the same version]
+```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ PM> Enable-Migrations
 
 Add Code First Migration
 ```
-PM> Add-Migrations [Give Your Migration Settings A name]
+PM> Add-Migration [Give Your Migration Settings A name]
 ```
 
 Update Database (Specify Verbose to see the SQL Querry that is being executed)
@@ -119,7 +119,6 @@ To do so, follow these steps:
 PM> Uninstall-Package MySQL.Data
 PM> Uninstall-Package MySQL.Data.Entity 
 ```
-` PM> Uninstall-Package MySQL.Data `
 3. Install the older packages:
 ```
 PM> Install-Package MySQL.Data -Version [type in the tabulator and you'll see the available versions] `


### PR DESCRIPTION
I've corrected the Add-Migration command, It was Add-Migrations which doesn't exist.
Also I've added an annotation that this tutorial also works with a MariaDB. I've tried it and it works.
And I've added a fix when a System.TypeLoadException caused by the MySQL packages occurs. This happened to me and I've solved this issue with the steps described.